### PR TITLE
feat: 게시물 수정기능 작성

### DIFF
--- a/apps/post/postController.js
+++ b/apps/post/postController.js
@@ -58,4 +58,28 @@ const deletePost = async (req, res, next) => {
   }
 };
 
-module.exports = { createPost, readPosts, deletePost };
+/**
+ * @description 게시물 단일 수정 기능
+ * */
+const updatePost = async (req, res, next) => {
+  try {
+    const { postId } = req.params;
+    const { password, title, content } = req.body;
+
+    if (!postId) {
+      throw new NotFoundError("Invalid URL");
+    }
+
+    if (!password && !title && !content) {
+      throw new BadRequestError("Key error");
+    }
+
+    const result = await postService.updatePost(postId, req.body);
+
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { createPost, readPosts, deletePost, updatePost };

--- a/apps/post/postDao.js
+++ b/apps/post/postDao.js
@@ -50,4 +50,15 @@ const deletePost = async (postId) => {
   return deleteCount;
 };
 
-module.exports = { createPost, readPosts, readPost, deletePost };
+/**
+ * @description posts 테이블의 자원을 수정 합니다.
+ * @param {number} postId 조회할 데이터 pk 값
+ * @returns {number}
+ */
+const updatePost = async (postId, upadateData) => {
+  const upadateRow = await Post.update(upadateData, { where: { id: postId } });
+
+  return upadateRow;
+};
+
+module.exports = { createPost, readPosts, readPost, deletePost, updatePost };

--- a/apps/post/postRouter.js
+++ b/apps/post/postRouter.js
@@ -10,4 +10,7 @@ router.get("", postController.readPosts);
 // 게시물 삭제
 router.delete("/:postId", postController.deletePost);
 
+// 게시물 수정
+router.patch("/:postId", postController.updatePost);
+
 module.exports = router;

--- a/apps/post/postService.js
+++ b/apps/post/postService.js
@@ -100,4 +100,37 @@ const deletePost = async (postId, password) => {
 
   return deletePost;
 };
-module.exports = { createPost, readPosts, deletePost };
+
+/**
+ * @description 게시물의 password와 pk를 받아 패스워드 검증후 데이터를 수정합니다.
+ * @param {string} postId 삭제할 게시물의 pk값입니다.
+ * @param {Object} reqBody 요청받은 request의 body를 그대로 전달받습니다.
+ * @param {string} reqBody.password 게시물 수정시 권한 검증을 위한 패스워드입니다. DB에 저장된 password와 일치하여야합니다.
+ * @param {string} reqBody.title 게시물 제목에 해당합니다.
+ * @param {string} reqBody.content 게시물 본문에 해당합니다.
+ * @returns
+ */
+const updatePost = async (postId, reqBody) => {
+  const { password, content, title } = reqBody;
+
+  // 데이터 유효성 검사
+  new Validator(reqBody);
+
+  const postRow = await postDao.readPost(postId);
+
+  if (!postRow) {
+    throw new NotFoundError("Invalid URL");
+  }
+  const postRowPassword = postRow.password;
+
+  const isSamePassword = await bcrypt.compare(password, postRowPassword);
+
+  // update시 사용할 객체의 default값으로 기존 데이터값을 지정합니다.
+  const postRowConfig = { titile: postRow.title, content: postRow.content };
+  const upadateData = Object.assign(postRowConfig, reqBody);
+
+  const result = await postDao.updatePost(postId, upadateData);
+
+  return result;
+};
+module.exports = { createPost, readPosts, deletePost, updatePost };


### PR DESCRIPTION
- path params로 게시물의 pk값을 가져옵니다.
- 유효하지않은 pk 값일 시 404 에러를 반환합니다.
- 비밀번호 검사 후 게시물 수정을 합니다.
- 빈 데이터가 들어올경우 데이터베이스에 존재하는 데이터값으으로 default값을 지정합니다.